### PR TITLE
Fixing unmappable character for encoding utf 8 error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
 				<configuration>
 					<source>${javaVersion}</source>
 					<target>${javaVersion}</target>
+					<encoding>ISO-8859-1</encoding>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
I was having trouble compiling on Windows. 

\goGPS\src\main\java\org\gogpsproject\parser\rtcm3\GlonassSatellite.java:[28,26]
error: unmappable character for encoding UTF-8
\goGPS\src\main\java\org\gogpsproject\parser\rtcm3\GlonassSatellite.java:[36,26]
error: unmappable character for encoding UTF-8
\goGPS\src\main\java\org\gogpsproject\util\UncompressInputStream.java:[5,41]
error: unmappable character for encoding UTF-8
\goGPS\src\main\java\org\gogpsproject\util\UncompressInputStream.java:[51,24]
error: unmappable character for encoding UTF-8

See http://stackoverflow.com/questions/8978013/error-unmappable-character-for-encoding-utf8-during-maven-compilation
